### PR TITLE
feat: add skip-install and skip-audit options to action inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,20 @@ PNPM version must be specified in `packageManager` in your `package.json`.
 
 ## Inputs
 
-| Name                | Description                                                  | Required | Default |
-|---------------------|--------------------------------------------------------------|----------|---------|
-| `node-version`      | Node.js version to use                                       | No       | `24.x`  |
-| `working-directory` | Working directory containing package.json and pnpm-lock.yaml | No       | `.`     |
+| Name                | Description                                                  | Required | Default  |
+|---------------------|--------------------------------------------------------------|----------|----------|
+| `node-version`      | Node.js version to use                                       | No       | `24.x`   |
+| `working-directory` | Working directory containing package.json and pnpm-lock.yaml | No       | `.`      |
+| `skip-install`      | Skip pnpm install step                                       | No       | `false`  |
+| `skip-audit`        | Skip pnpm audit step                                         | No       | `false`  |
 
 ## Outputs
 
 None
 
 ## Usage
+
+### Minimal
 
 ```yaml
 on:
@@ -29,12 +33,27 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
+      - uses: Arbeidstilsynet/action-pnpm-setup@v1
+```
 
+### With all optional inputs
+
+```yaml
+on:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
       - uses: Arbeidstilsynet/action-pnpm-setup@v1
         with:
           node-version: "24.x"
           working-directory: "some/path"
+          skip-install: false
+          skip-audit: false
 ```
 
 ## Versioning

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ inputs:
     description: "Working directory containing package.json and pnpm-lock.yaml"
     default: "."
     required: false
+  skip-install:
+    description: "Skip pnpm install step"
+    default: "false"
+    required: false
+  skip-audit:
+    description: "Skip pnpm audit step"
+    default: "false"
+    required: false
 
 runs:
   using: composite
@@ -28,13 +36,19 @@ runs:
     - shell: bash
       run: pnpm --version
       working-directory: ${{ inputs.working-directory }}
+
     - shell: bash
+      if: ${{ inputs.skip-audit != 'true' }}
       run: pnpm audit
       working-directory: ${{ inputs.working-directory }}
+
     - shell: bash
+      if: ${{ inputs.skip-install != 'true' }}
       run: pnpm install
       working-directory: ${{ inputs.working-directory }}
+
     - name: "List packages"
       shell: bash
+      if: ${{ inputs.skip-install != 'true' }}
       run: pnpm ls -r --depth 0
       working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
`skip-audit` is sometimes needed when upstream has issues such as https://github.com/pnpm/pnpm/issues/11265

`skip-install` can be used to easily configure Node and PNPM only for running scripts